### PR TITLE
Add deleteAttachedFile endpoint

### DIFF
--- a/src/integration/storage/storage.manager.ts
+++ b/src/integration/storage/storage.manager.ts
@@ -43,6 +43,15 @@ export class StorageManager {
     }
   }
 
+  async delete(path: string, disk = DriverType.LOCAL): Promise<boolean> {
+    try {
+      await this.storage.getDisk(disk).delete(path);
+      return true;
+    } catch (error) {
+      throw error.message;
+    }
+  }
+
 }
 
 export interface StoreFileOptions {

--- a/src/modules/attached-files/attached-files.controller.ts
+++ b/src/modules/attached-files/attached-files.controller.ts
@@ -2,6 +2,7 @@ import {
   Body,
   ClassSerializerInterceptor,
   Controller,
+  Delete,
   Get,
   Param,
   Post,
@@ -28,6 +29,7 @@ import { PageMetaDto } from 'src/core/helpers/pagination/page-meta.dto';
 import { PageDto } from 'src/core/helpers/pagination/page.dto';
 import { Roles } from '../authentication/guards/roles.decorator';
 import { Role } from 'src/infrastructure/data/enums/role.enum';
+import { RfpOwnerGuard } from '../multi-rfp/guards/rfp_owner.guard';
 @ApiBearerAuth()
 @ApiHeader({
   name: 'Accept-Language',
@@ -38,13 +40,13 @@ import { Role } from 'src/infrastructure/data/enums/role.enum';
 @UseGuards(JwtAuthGuard, RolesGuard)
 @Controller('attached-files')
 export class AttachedFilesController {
-  constructor(private readonly attachedFilesService: AttachedFilesService) {}
+  constructor(private readonly attachedFilesService: AttachedFilesService) { }
 
   @Get(':id')
-  async getAllAttachedFiles(@Param('id') id: string,@Query() attachedFilesFilterRequest: AttachedFilesFilterRequest) {
+  async getAllAttachedFiles(@Param('id') id: string, @Query() attachedFilesFilterRequest: AttachedFilesFilterRequest) {
     const { limit, page } = attachedFilesFilterRequest;
 
-    const {attachedFilesDto,count} = await this.attachedFilesService.getAllAttachedFilesForProject(id,attachedFilesFilterRequest)
+    const { attachedFilesDto, count } = await this.attachedFilesService.getAllAttachedFilesForProject(id, attachedFilesFilterRequest)
 
     const pageMetaDto = new PageMetaDto(page, limit, count);
 
@@ -62,6 +64,14 @@ export class AttachedFilesController {
     createAttachedFilesRequest.file = file;
     return new ActionResponse(
       await this.attachedFilesService.addAttachedFileToProject(createAttachedFilesRequest),
+    );
+  }
+
+  @Roles(Role.CLIENT)
+  @Delete(':id')
+  async deleteAttachedFile(@Param('id') id: string) {
+    return new ActionResponse(
+      await this.attachedFilesService.deleteAttachedFile(id),
     );
   }
 }


### PR DESCRIPTION
## Description
This pull request adds a new endpoint `deleteAttachedFile` to the `AttachedFilesController` for deleting an attached file. It also includes the necessary logic in the `AttachedFilesService` and `StorageManager` to handle the deletion process.

## Changes Made
- Added `deleteAttachedFile` endpoint to `AttachedFilesController`
- Implemented `deleteAttachedFile` method in `AttachedFilesService`
- Added `delete` method in `StorageManager` to handle file deletion


## Sequence Diagram
![delete attached drawio](https://github.com/ahmedmaghraby1996/symlink-api/assets/57197702/58a8193c-3d33-4845-a811-0a769504ab1b)
