### PR TITLE
Enhancement: Allow Updating Existing Request for Proposals and Adding New Ones :fire: :rocket: 

### DIFF
--- a/src/modules/multi-rfp/multi-rfp.service.ts
+++ b/src/modules/multi-rfp/multi-rfp.service.ts
@@ -23,7 +23,7 @@ export class MultiRfpService extends BaseService<MultiRFP> {
     @InjectRepository(MultiRFP)
     private multiRFPRepository: Repository<MultiRFP>,
     @Inject(REQUEST) private readonly request: Request,
-    @Inject(RequestForProposalService) private readonly requestforPrposal: RequestForProposalService,
+    @Inject(RequestForProposalService) private readonly requestforPrposalService: RequestForProposalService,
   ) {
     super(multiRFPRepository);
   }
@@ -192,9 +192,16 @@ export class MultiRfpService extends BaseService<MultiRFP> {
 
     // Update individual RFPs within the MultiRFP based on the provided request data.
     if (updateMultiRFPRequest.projects) {
-      updateMultiRFPRequest.projects.forEach(async (request_for_proposal) => {
-        await this.requestforPrposal.updateRequestForProposal(request_for_proposal);
-      });
+      for (const request_for_proposal of updateMultiRFPRequest.projects) {
+        if (request_for_proposal.id !== undefined) {
+          await this.requestforPrposalService.updateRequestForProposal(request_for_proposal);
+        } else {
+          const requestForProposalCreate = this.requestForProposalRepository.create(
+            { ...request_for_proposal, multi_RFP: multiRFP },
+          );
+          await this.requestForProposalRepository.save(requestForProposalCreate);
+        }
+      }
     }
 
     const updatedMultiRFP = plainToInstance(MultiRFP, updateMultiRFPRequest);

--- a/src/modules/request-for-proposal/dto/update-request-for-propsal.request.ts
+++ b/src/modules/request-for-proposal/dto/update-request-for-propsal.request.ts
@@ -1,14 +1,14 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { Transform } from 'class-transformer';
-import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { IsNotEmpty, IsOptional, IsString, ValidateIf } from 'class-validator';
 import { CreateRequestForProposalRequest } from './create-request-for-proposal.request';
 
 export class UpdateRequestForProposalRequest extends CreateRequestForProposalRequest {
-    @IsOptional()
+    @ValidateIf((object, value) => !object.id) // Only validate if `id` doesn't exist
+    @IsNotEmpty()
     category_id: string;
 
     @ApiProperty({ nullable: false, required: true })
-    @IsNotEmpty()
+    @IsOptional()
     @IsString()
     id: string;
 }

--- a/src/modules/request-for-proposal/request-for-proposal.service.ts
+++ b/src/modules/request-for-proposal/request-for-proposal.service.ts
@@ -52,7 +52,7 @@ export class RequestForProposalService {
     );
 
     if (!requestForProposalUpdate) {
-      throw new NotFoundException('Not found');
+      throw new NotFoundException('Assesment Not found');
     }
 
     Object.assign(requestForProposalUpdate, requestForProposal);


### PR DESCRIPTION
## Description :speech_balloon: 

This pull request enhances the `updateMultiRFP` method in order to allow updating existing request for proposals (RFPs projects) or adding new ones within the MultiRFP entity. The changes also include custom validation logic for the `category_id` property using the `IsNotEmpty` decorator.

## Changes Made :recycle: 

- Modified the `updateMultiRFP` method in the `MultiRFPService` class to support updating existing RFPs or adding new ones.
- Replaced the `forEach` loop with a `for...of` loop for better asynchronous handling.
- Implemented conditional logic based on the existence of the `id` property in the `updateMultiRFPRequest.projects` array.
- Added appropriate validation logic to the `category_id` property in the `UpdateRequestForProposalRequest` DTO using the `ValidateIf` and `IsNotEmpty` decorators.

## Checklist :white_check_mark: 

- [x] Updated the `updateMultiRFP` method to allow updating existing RFPs or adding new ones.
- [x] Replaced the `forEach` loop with a `for...of` loop for better asynchronous handling.
- [x] Implemented conditional logic based on the existence of the `id` property.
- [x] Added validation logic to the `category_id` property in the `UpdateRequestForProposalRequest` DTO.

---
<p align="center"> @ahmedeid6842 </p>
<p align="center">
  <img src="https://user-images.githubusercontent.com/57197702/235438155-a0422937-6810-4e50-b887-9e20e5e49270.gif" alt="200w">
</p>