### PR TITLE
Fixed Ticket Attach Path :link: 

### DIFF
--- a/src/integration/gateways/discussion.gateway.ts
+++ b/src/integration/gateways/discussion.gateway.ts
@@ -47,7 +47,7 @@ export class DiscussionGateway {
             }
 
             if (
-                payload.multi_RFP.request_for_proposal_status === RequestForProposalStatus.APPROVED &&
+                payload.multi_RFP?.request_for_proposal_status === RequestForProposalStatus.APPROVED &&
                 socket.user &&
                 (
                     socket.user.id === payload.multi_RFP.user_id ||
@@ -58,7 +58,7 @@ export class DiscussionGateway {
                 delete payload.multi_RFP;
                 socket.emit(room, payload);
             } else if (
-                payload.multi_RFP.request_for_proposal_status !== RequestForProposalStatus.APPROVED
+                payload.multi_RFP?.request_for_proposal_status !== RequestForProposalStatus.APPROVED
             ) {
                 delete payload.multi_RFP;
                 socket.emit(room, payload);

--- a/src/modules/support-ticket/support-ticket.service.ts
+++ b/src/modules/support-ticket/support-ticket.service.ts
@@ -33,7 +33,7 @@ export class SupportTicketService extends BaseService<SupportTicket> {
             uploadFileRequest.file = file;
             const tempImage = await this._fileService.upload(
                 uploadFileRequest,
-                `support-tickets/${this.currentUser.id}`,
+                `support-tickets`,
             );
 
             const createAttachedFile = this.ticketAttachmentRepository.create({

--- a/src/modules/support-ticket/ticket-comment.service.ts
+++ b/src/modules/support-ticket/ticket-comment.service.ts
@@ -34,7 +34,7 @@ export class TicketCommentService extends BaseService<TicketComment> {
             uploadFileRequest.file = file;
             const tempImage = await this._fileService.upload(
                 uploadFileRequest,
-                `support-tickets/${this.currentUser.id}`,
+                `support-tickets`,
             );
 
             const createAttachedFile = this.ticketAttachmentRepository.create({


### PR DESCRIPTION
- [x] Fixed URL for support ticket comments attachments to store at the right path `support-tickets`
- [x] Added Null check for discussion gateway. 